### PR TITLE
Fix ReActor URL

### DIFF
--- a/projects/comfyui/custom-nodes/default.nix
+++ b/projects/comfyui/custom-nodes/default.nix
@@ -45,7 +45,7 @@
   reactorModels = let
     reactorModel = file: sha256:
       fetchFromUrl {
-        url = "https://huggingface.co/datasets/Gourieff/resolve/main/ReActor/models/${file}";
+        url = "https://huggingface.co/datasets/Gourieff/ReActor/resolve/main/models/${file}";
         inherit sha256;
       };
   in {


### PR DESCRIPTION
Fixed ReActor URL, before, I got the following error:
```
last 8 log lines:
       > error:
       >        … writing file '/nix/store/msr51qi52wsir5hb9h14kdmrdpd5ci8c-inswapper_128.onnx'
       >
       >        error: unable to download 'https://huggingface.co/datasets/Gourieff/resolve/main/ReActor/models/inswapper_128.onnx': HTTP error 401
       >
       >        response body:
       >
       >        Invalid username or password.
```